### PR TITLE
Niloofar/ Added URLs Constants and Utils

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "tabWidth": 4,
+    "printWidth": 120
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@vitest/coverage-istanbul": "^1.2.2",
                 "@vitest/coverage-v8": "^1.2.2",
                 "happy-dom": "^13.3.8",
+                "prettier": "3.2.5",
                 "typescript": "^5.3.3",
                 "vite": "^5.1.2",
                 "vite-plugin-dts": "^3.7.2",
@@ -2497,6 +2498,21 @@
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "@vitest/coverage-istanbul": "^1.2.2",
         "@vitest/coverage-v8": "^1.2.2",
         "happy-dom": "^13.3.8",
+        "prettier": "3.2.5",
         "typescript": "^5.3.3",
         "vite": "^5.1.2",
         "vite-plugin-dts": "^3.7.2",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,6 @@
 import * as AppIDConstants from "./app-id.constants";
 import * as CurrencyConstants from "./currency.constants";
 import * as LocalStorageConstants from "./localstorage.constants";
+import * as URLConstants from "./url.constants";
 
-export { AppIDConstants, CurrencyConstants, LocalStorageConstants };
+export { AppIDConstants, CurrencyConstants, LocalStorageConstants, URLConstants };

--- a/src/constants/url.constants.ts
+++ b/src/constants/url.constants.ts
@@ -1,0 +1,20 @@
+export const deriv = 'deriv.com';
+export const derivMe = 'deriv.me';
+export const derivBe = 'deriv.be';
+
+export const supportedDomains = [deriv, derivBe, derivMe]
+
+export const binaryBotProduction = `https://bot.${domainUrl}`
+
+
+
+// BINARYBOT_PRODUCTION: ,
+//     BINARYBOT_STAGING: `https://staging-bot.${domainUrl}`,
+//     DERIV_APP_PRODUCTION: `https://app.${domainUrl}`,
+//     DERIV_APP_STAGING: `https://staging-app.${domainUrl}`,
+//     DERIV_COM_PRODUCTION: `https://${domainUrl}`,
+//     DERIV_COM_PRODUCTION_EU: `https://eu.${domainUrl}`,
+//     DERIV_COM_STAGING: `https://staging.${domainUrl}`,
+//     DERIV_HOST_NAME: domainUrl,
+//     SMARTTRADER_PRODUCTION: `https://smarttrader.${domainUrl}`,
+//     SMARTTRADER_STAGING: `https://staging-smarttrader.${domainUrl}`,

--- a/src/constants/url.constants.ts
+++ b/src/constants/url.constants.ts
@@ -1,20 +1,30 @@
-export const deriv = 'deriv.com';
-export const derivMe = 'deriv.me';
-export const derivBe = 'deriv.be';
+export const deriv = "deriv.com";
+export const derivMe = "deriv.me";
+export const derivBe = "deriv.be";
 
-export const supportedDomains = [deriv, derivBe, derivMe]
+export const supportedDomains = [deriv, derivBe, derivMe] as const;
+export const baseDomain = (typeof window !== "undefined" &&
+    window.location.hostname.split("app.")[1]) as (typeof supportedDomains)[number];
+export const domain = supportedDomains.includes(baseDomain) ? baseDomain : deriv;
 
-export const binaryBotProduction = `https://bot.${domainUrl}`
+// deriv URLs
+export const binaryBotProduction = `https://bot.${domain}` as const;
+export const binaryBotStaging = `https://staging-bot.${domain}` as const;
+export const derivAppProduction = `https://app.${domain}` as const;
+export const derivAppStaging = `https://staging-app.${domain}` as const;
+export const derivComProduction = `https://${domain}` as const;
+export const derivComProductionEU = `https://eu.${domain}` as const;
+export const derivComStaging = `https://staging.${domain}` as const;
+export const derivHost = domain;
+export const smartTraderProduction = `https://smarttrader.${domain}` as const;
+export const smartTraderStaging = `https://staging-smarttrader.${domain}` as const;
+//
 
+export const whatsApp = "https://wa.me/35699578341";
 
+export const queryParameters = {
+    lang: "lang",
+    action: "action",
+} as const;
 
-// BINARYBOT_PRODUCTION: ,
-//     BINARYBOT_STAGING: `https://staging-bot.${domainUrl}`,
-//     DERIV_APP_PRODUCTION: `https://app.${domainUrl}`,
-//     DERIV_APP_STAGING: `https://staging-app.${domainUrl}`,
-//     DERIV_COM_PRODUCTION: `https://${domainUrl}`,
-//     DERIV_COM_PRODUCTION_EU: `https://eu.${domainUrl}`,
-//     DERIV_COM_STAGING: `https://staging.${domainUrl}`,
-//     DERIV_HOST_NAME: domainUrl,
-//     SMARTTRADER_PRODUCTION: `https://smarttrader.${domainUrl}`,
-//     SMARTTRADER_STAGING: `https://staging-smarttrader.${domainUrl}`,
+export type queryParameters = keyof typeof queryParameters;

--- a/src/constants/url.constants.ts
+++ b/src/constants/url.constants.ts
@@ -27,4 +27,4 @@ export const queryParameters = {
     action: "action",
 } as const;
 
-export type queryParameters = keyof typeof queryParameters;
+export type QueryParameters = keyof typeof queryParameters;

--- a/src/utils/__test__/url.utils.spec.ts
+++ b/src/utils/__test__/url.utils.spec.ts
@@ -209,13 +209,13 @@ describe("URLUtils.getWebsocketURL", () => {
     });
 });
 
-describe("URLUtils.getURLParameters", () => {
+describe("URLUtils.getQueryParameter", () => {
     test("returns the value for the 'lang' key", () => {
         Object.defineProperty(window, "location", {
             value: { search: "?lang=ES" },
         });
 
-        const URLParameters = URLUtils.getURLParameters("lang");
+        const URLParameters = URLUtils.getQueryParameter("lang");
         expect(URLParameters).toBe("ES");
     });
 
@@ -224,7 +224,7 @@ describe("URLUtils.getURLParameters", () => {
             value: { search: "?lang=ES&action=test" },
         });
 
-        const URLParameters = URLUtils.getURLParameters("lang");
+        const URLParameters = URLUtils.getQueryParameter("lang");
         expect(URLParameters).toBe("ES");
     });
 
@@ -233,7 +233,7 @@ describe("URLUtils.getURLParameters", () => {
             value: { search: "?lang=ES" },
         });
 
-        const URLParameters = URLUtils.getURLParameters("action");
+        const URLParameters = URLUtils.getQueryParameter("action");
         expect(URLParameters).toBeNull();
     });
 });

--- a/src/utils/__test__/url.utils.spec.ts
+++ b/src/utils/__test__/url.utils.spec.ts
@@ -210,20 +210,31 @@ describe("URLUtils.getWebsocketURL", () => {
 });
 
 describe("URLUtils.getURLParameters", () => {
-    beforeEach(() => {
+    test("returns the value for the 'lang' key", () => {
+        Object.defineProperty(window, "location", {
+            value: { search: "?lang=ES" },
+        });
+
+        const URLParameters = URLUtils.getURLParameters("lang");
+        expect(URLParameters).toBe("ES");
+    });
+
+    test("returns the value for the 'lang' key when we have multiple query parameters", () => {
         Object.defineProperty(window, "location", {
             value: { search: "?lang=ES&action=test" },
         });
+
+        const URLParameters = URLUtils.getURLParameters("lang");
+        expect(URLParameters).toBe("ES");
     });
 
-    test("returns the value for lang key", () => {
-        const result = URLUtils.getURLParameters("lang");
-        expect(result).toBe("ES");
-    });
+    test("returns null when we don't have value for the passed key", () => {
+        Object.defineProperty(window, "location", {
+            value: { search: "?lang=ES" },
+        });
 
-    test("returns the value for action key", () => {
-        const result = URLUtils.getURLParameters("action");
-        expect(result).toBe("test");
+        const URLParameters = URLUtils.getURLParameters("action");
+        expect(URLParameters).toBeNull();
     });
 });
 
@@ -234,7 +245,7 @@ describe("URLUtils.normalizePath", () => {
     });
 
     test("removes invalid characters", () => {
-        const result = URLUtils.normalizePath("inval!d_c#haracters");
+        const result = URLUtils.normalizePath("inval!d_characters");
         expect(result).toBe("invald_characters");
     });
 

--- a/src/utils/__test__/url.utils.spec.ts
+++ b/src/utils/__test__/url.utils.spec.ts
@@ -208,3 +208,38 @@ describe("URLUtils.getWebsocketURL", () => {
         expect(output).toBe("wss://ws.derivws.com/websockets/v3?app_id=777&l=FR&brand=deriv");
     });
 });
+
+describe("URLUtils.getURLParameters", () => {
+    beforeEach(() => {
+        Object.defineProperty(window, "location", {
+            value: { search: "?lang=ES&action=test" },
+        });
+    });
+
+    test("returns the value for lang key", () => {
+        const result = URLUtils.getURLParameters("lang");
+        expect(result).toBe("ES");
+    });
+
+    test("returns the value for action key", () => {
+        const result = URLUtils.getURLParameters("action");
+        expect(result).toBe("test");
+    });
+});
+
+describe("URLUtils.normalizePath", () => {
+    test("removes leading and trailing slashes", () => {
+        const result = URLUtils.normalizePath("/example/path/");
+        expect(result).toBe("example/path");
+    });
+
+    test("removes invalid characters", () => {
+        const result = URLUtils.normalizePath("inval!d_c#haracters");
+        expect(result).toBe("invald_characters");
+    });
+
+    test("handles an empty path", () => {
+        const result = URLUtils.normalizePath("");
+        expect(result).toBe("");
+    });
+});

--- a/src/utils/__test__/url.utils.spec.ts
+++ b/src/utils/__test__/url.utils.spec.ts
@@ -276,23 +276,26 @@ describe("URLUtils.getDerivStaticURL", () => {
     });
 
     test("getDerivStaticURL with path and isEU true", () => {
-        const result = URLUtils.getDerivStaticURL("/p2p/", false, true);
+        const result = URLUtils.getDerivStaticURL("/p2p/", { isEU: true });
         expect(result).toBe("https://eu.deriv.com/p2p");
     });
 
     test("getDerivStaticURL with path and isDocument true and default language", () => {
-        const result = URLUtils.getDerivStaticURL("/p2p/", true);
-        expect(result).toBe("https://deriv.com/p2p");
+        const result = URLUtils.getDerivStaticURL("regulatory/deriv-com-ltd-membership.pdf", { isDocument: true });
+        expect(result).toBe("https://deriv.com/regulatory/deriv-com-ltd-membership.pdf");
     });
 
     test("getDerivStaticURL with path and isDocument true and Spanish language", () => {
         localStorage.getItem = vitest.fn(() => "ES");
-        const result = URLUtils.getDerivStaticURL("/p2p/", true);
-        expect(result).toBe("https://deriv.com/p2p");
+        const result = URLUtils.getDerivStaticURL("regulatory/deriv-com-ltd-membership.pdf", { isDocument: true });
+        expect(result).toBe("https://deriv.com/regulatory/deriv-com-ltd-membership.pdf");
     });
 
     test("getDerivStaticURL with path and isEU true and isDocument true", () => {
-        const result = URLUtils.getDerivStaticURL("/p2p/", true, true);
-        expect(result).toBe("https://eu.deriv.com/p2p");
+        const result = URLUtils.getDerivStaticURL("regulatory/deriv-com-ltd-membership.pdf", {
+            isDocument: true,
+            isEU: true,
+        });
+        expect(result).toBe("https://eu.deriv.com/regulatory/deriv-com-ltd-membership.pdf");
     });
 });

--- a/src/utils/__test__/url.utils.spec.ts
+++ b/src/utils/__test__/url.utils.spec.ts
@@ -254,3 +254,45 @@ describe("URLUtils.normalizePath", () => {
         expect(result).toBe("");
     });
 });
+
+describe("URLUtils.getDerivStaticURL", () => {
+    test("getDerivStaticURL with path and default language(en)", () => {
+        const result = URLUtils.getDerivStaticURL("/p2p/");
+        expect(result).toBe("https://deriv.com/p2p");
+    });
+
+    test("getDerivStaticURL with path and Spanish language", () => {
+        localStorage.getItem = vitest.fn(() => "ES");
+
+        const result = URLUtils.getDerivStaticURL("/p2p/");
+        expect(result).toBe("https://deriv.com/es/p2p");
+    });
+
+    test("getDerivStaticURL with path and language that contains '_'", () => {
+        localStorage.getItem = vitest.fn(() => "ZH_TW");
+
+        const result = URLUtils.getDerivStaticURL("/p2p/");
+        expect(result).toBe("https://deriv.com/zh-tw/p2p");
+    });
+
+    test("getDerivStaticURL with path and isEU true", () => {
+        const result = URLUtils.getDerivStaticURL("/p2p/", false, true);
+        expect(result).toBe("https://eu.deriv.com/p2p");
+    });
+
+    test("getDerivStaticURL with path and isDocument true and default language", () => {
+        const result = URLUtils.getDerivStaticURL("/p2p/", true);
+        expect(result).toBe("https://deriv.com/p2p");
+    });
+
+    test("getDerivStaticURL with path and isDocument true and Spanish language", () => {
+        localStorage.getItem = vitest.fn(() => "ES");
+        const result = URLUtils.getDerivStaticURL("/p2p/", true);
+        expect(result).toBe("https://deriv.com/p2p");
+    });
+
+    test("getDerivStaticURL with path and isEU true and isDocument true", () => {
+        const result = URLUtils.getDerivStaticURL("/p2p/", true, true);
+        expect(result).toBe("https://eu.deriv.com/p2p");
+    });
+});

--- a/src/utils/url.utils.ts
+++ b/src/utils/url.utils.ts
@@ -119,7 +119,7 @@ export const getWebsocketURL = () => {
  * @param {QueryParameters} key - The query parameter we want. (you can see all of them in the URLConstants.queryParameters)
  * @returns {string | null} A string containing query parameter associated with the given key.
  */
-export const getURLParameters = (key: QueryParameters) => {
+export const getQueryParameter = (key: QueryParameters) => {
     const searchParams = new URLSearchParams(window.location.search);
     return searchParams.get(key);
 };

--- a/src/utils/url.utils.ts
+++ b/src/utils/url.utils.ts
@@ -145,23 +145,12 @@ export const normalizePath = (path: string) => path.replace(/(^\/|\/$|[^a-zA-Z0-
  * @param {boolean} [isEU=false] - Specifies whether the URL should be generated for the EU production environment.
  * @returns {string} Returns the formatted static URL.
  */
-export const generateDerivStaticURL = (path: string, isDocument?: boolean, isEU?: boolean) => {
-    const { derivComProductionEU, derivComProduction } = URLConstants;
-    const { i18nLanguage } = LocalStorageConstants;
+export const getDerivStaticURL = (path: string, isDocument?: boolean, isEU?: boolean) => {
+    const host = isEU ? URLConstants.derivComProductionEU : URLConstants.derivComProduction;
+    let lang = localStorage.getItem(LocalStorageConstants.i18nLanguage)?.toLowerCase() ?? "en";
 
-    const host = isEU ? derivComProductionEU : derivComProduction;
-    let lang = localStorage.getItem(i18nLanguage)?.toLowerCase();
-
-    if (lang && lang !== "en") {
-        lang = `/${lang}`;
-    } else lang = "";
+    lang = lang === "en" ? "" : `/${lang.replace("_", "-")}`;
 
     if (isDocument) return `${host}/${normalizePath(path)}`;
-
-    // Deriv.com uses '-' instead of '_' for language separation.
-    if (lang.includes("_")) {
-        lang = lang.replace("_", "-");
-    }
-
     return `${host}${lang}/${normalizePath(path)}`;
 };

--- a/src/utils/url.utils.ts
+++ b/src/utils/url.utils.ts
@@ -2,11 +2,6 @@ import { LocalStorageConstants, AppIDConstants, URLConstants } from "../constant
 import { QueryParameters } from "../constants/url.constants";
 import { getActiveLoginid, getAppId, getEnvironmentFromLoginid } from "./websocket.utils";
 
-type DerivStaticURLOptions = {
-    isDocument?: boolean;
-    isEU?: boolean;
-};
-
 /**
  * Defines the structure for account information.
  * @typedef {Object} AccountInfo
@@ -141,6 +136,11 @@ export const getQueryParameter = (key: QueryParameters) => {
  * @returns {string} Returns the formatted path without the specified characters.
  */
 export const normalizePath = (path: string) => path.replace(/(^\/|\/$|[^a-zA-Z0-9-_./()#])/g, "");
+
+type DerivStaticURLOptions = {
+    isDocument?: boolean;
+    isEU?: boolean;
+};
 
 /**
  * Generates a static URL for the deriv.com project based on the provided parameters.

--- a/src/utils/url.utils.ts
+++ b/src/utils/url.utils.ts
@@ -2,6 +2,11 @@ import { LocalStorageConstants, AppIDConstants, URLConstants } from "../constant
 import { QueryParameters } from "../constants/url.constants";
 import { getActiveLoginid, getAppId, getEnvironmentFromLoginid } from "./websocket.utils";
 
+type DerivStaticURLOptions = {
+    isDocument?: boolean;
+    isEU?: boolean;
+};
+
 /**
  * Defines the structure for account information.
  * @typedef {Object} AccountInfo
@@ -142,16 +147,18 @@ export const normalizePath = (path: string) => path.replace(/(^\/|\/$|[^a-zA-Z0-
  * This function is necessary because deriv.com URLs differ from those used in app.deriv.com
  *
  * @param {string} path - The path to be appended to the base URL.
- * @param {boolean} [isDocument=false] - Specifies whether the path represents a document.
- * @param {boolean} [isEU=false] - Specifies whether the URL should be generated for the EU production environment.
+ * @param {DerivStaticURLOptions} [options] - Optional configuration for customising the Deriv Static URL, including:
+ *   - `isDocument`: Specifies whether the path represents a document.
+ *   - `isEU`: Specifies whether the URL should be generated for the EU production environment.
+ *
  * @returns {string} Returns the formatted static URL.
  */
-export const getDerivStaticURL = (path: string, isDocument?: boolean, isEU?: boolean) => {
-    const host = isEU ? URLConstants.derivComProductionEU : URLConstants.derivComProduction;
+export const getDerivStaticURL = (path: string, options?: DerivStaticURLOptions) => {
+    const host = options?.isEU ? URLConstants.derivComProductionEU : URLConstants.derivComProduction;
     let lang = localStorage.getItem(LocalStorageConstants.i18nLanguage)?.toLowerCase() ?? "en";
 
     lang = lang === "en" ? "" : `/${lang.replace("_", "-")}`;
 
-    if (isDocument) return `${host}/${normalizePath(path)}`;
+    if (options?.isDocument) return `${host}/${normalizePath(path)}`;
     return `${host}${lang}/${normalizePath(path)}`;
 };

--- a/src/utils/url.utils.ts
+++ b/src/utils/url.utils.ts
@@ -113,14 +113,14 @@ export const getWebsocketURL = () => {
 };
 
 /**
- * Extracts query parameters from the URL by parsing the current window's URL search parameters for the specified key.
- * It returns the query parameters associated with the given key.
+ * Extracts query parameters from the URL by parsing the current window's URL search parameters for the specified keys.
+ * It returns the query parameters associated with the given keys.
  *
- * @returns {string | null} A string containing query parameter associated with the given key.
+ * @returns {Array<string | null>} An array of strings containing query parameters associated with the given key.
  */
-export const getURLParameters = (key: queryParameters) => {
+export const getURLParameters = (keys: queryParameters[]) => {
     const searchParams = new URLSearchParams(window.location.search);
-    return searchParams.get(key);
+    return keys.map((key) => searchParams.get(key));
 };
 
 /**

--- a/src/utils/url.utils.ts
+++ b/src/utils/url.utils.ts
@@ -1,5 +1,5 @@
 import { LocalStorageConstants, AppIDConstants, URLConstants } from "../constants";
-import { queryParameters } from "../constants/url.constants";
+import { QueryParameters } from "../constants/url.constants";
 import { getActiveLoginid, getAppId, getEnvironmentFromLoginid } from "./websocket.utils";
 
 /**
@@ -113,14 +113,15 @@ export const getWebsocketURL = () => {
 };
 
 /**
- * Extracts query parameters from the URL by parsing the current window's URL search parameters for the specified keys.
- * It returns the query parameters associated with the given keys.
+ * Extracts query parameters from the URL by parsing the current window's URL search parameters for the specified key.
+ * It returns the query parameters associated with the given key.
  *
- * @returns {Array<string | null>} An array of strings containing query parameters associated with the given key.
+ * @param {QueryParameters} key - The query parameter we want. (you can see all of them in the URLConstants.queryParameters)
+ * @returns {string | null} A string containing query parameter associated with the given key.
  */
-export const getURLParameters = (keys: queryParameters[]) => {
+export const getURLParameters = (key: QueryParameters) => {
     const searchParams = new URLSearchParams(window.location.search);
-    return keys.map((key) => searchParams.get(key));
+    return searchParams.get(key);
 };
 
 /**


### PR DESCRIPTION
**_List of Added constants:_** 

```
deriv = "deriv.com";
derivMe = "deriv.me";
derivBe = "deriv.be";

supportedDomains = [deriv, derivBe, derivMe]

// deriv URLs
binaryBotProduction = `https://bot.${domain}`;
binaryBotStaging = `https://staging-bot.${domain}`;
derivAppProduction = `https://app.${domain}`;
derivAppStaging = `https://staging-app.${domain}`;
derivComProduction = `https://${domain}`;
derivComProductionEU = `https://eu.${domain}`;
derivComStaging = `https://staging.${domain}`;
derivHost = domain;
smartTraderProduction = `https://smarttrader.${domain}`;
smartTraderStaging = `https://staging-smarttrader.${domain}`;
//

whatsApp = "https://wa.me/35699578341";

queryParameters = {
    lang: "lang",
    action: "action",
}
```

---

**_List of Added Utils:_**

1. `getDerivStaticURL`

```
/**
 * Generates a static URL for the deriv.com project based on the provided parameters.
 * This function is necessary because deriv.com URLs differ from those used in app.deriv.com
 *
 * @param {string} path - The path to be appended to the base URL.
 * @param {DerivStaticURLOptions} [options] - Optional configuration for customising the Deriv Static URL, including:
 *   - `isDocument`: Specifies whether the path represents a document.
 *   - `isEU`: Specifies whether the URL should be generated for the EU production environment.
 *
 * @returns {string} Returns the formatted static URL.
 */
```
By using this we no more need `getStaticUrl` and we can remove it from our Utils.

2. `normalizePath`

```
/**
 * Takes a 'URL path' as input and removes certain characters from the beginning and end of the path.
 *
 * Removes the following:
 * - Any leading forward slash (/) at the beginning of the path.
 * - Any trailing forward slash (/) at the end of the path.
 * - Any characters that are not alphanumeric, hyphen, underscore, dot, forward slash, parentheses, or hash symbol.
 *
 * @param {string} path - The URL path that needs to be normalized.
 * @returns {string} Returns the formatted path without the specified characters.
 */
```
By using this we no more need `normalizePath` and we can remove it from our Utils.

3. `getQueryParameter`

```
/**
 * Extracts query parameters from the URL by parsing the current window's URL search parameters for the specified key.
 * It returns the query parameters associated with the given key.
 *
 * @returns {string | null} A string containing query parameter associated with the given key.
 */
```

The passing key is type safe and you can use them from URLConstants.queryParameters.
By using this function we no more need `getlangFromUrl` and `getActionFromUrl` so we can remove duplicated codes and use this instead.

---

By using these utils and constants we no more need these files:

- packages/shared/src/utils/url/constants.ts
- packages/tradershub/src/helpers/urls.ts
- packages/library/src/helpers/url.helpers.ts
- packages/wallets/src/helpers/urls.ts
- packages/shared/src/utils/url/helpers.ts