### PR TITLE
Mitra/KYC-1852/Update the regex for first and last name validation

### DIFF
--- a/src/constants/validation.constants.ts
+++ b/src/constants/validation.constants.ts
@@ -147,14 +147,14 @@ export const patterns = {
      */
     letterSymbols: /^[A-Za-z]+([a-zA-Z.' -])*[a-zA-Z.' -]+$/,
     /**
-     * @regex /^(?!.*\s{2,})[\p{L}\s'.-]{2,50}$/u
-     * @description This pattern matches any string that contains 2-50 characters, starts and ends with valid characters (letters, whitespace, period, single quote, or hyphen).
+     * @regex /^(?!.*\s{2,})(?!\s)[\p{L}\s'.-]{1,50}(?<!\s)$/u
+     * @description This pattern matches any string that contains 1 to 50 characters, starts and ends with valid characters (letters, whitespace, period, single quote, or hyphen).
      * @example ValidationConstants.patterns.name.test("John Doe")
      * @example ValidationConstants.patterns.name.test("John-Doe")
      * @example ValidationConstants.patterns.name.test("John O'Doe")
      * @example ValidationConstants.patterns.name.test("John O. Doe")
      */
-    name: /^(?!.*\s{2,})[\p{L}\s'.-]{2,50}$/u,
+    name: /^(?!.*\s{2,})(?!\s)[\p{L}\s'.-]{1,50}(?<!\s)$/u,
     /**
      * @regex /[`~!@#$%^&*)(_=+[}{\]\\/";:?><|]+/
      * @description This pattern matches any string that contains any of these characters: `~!@#$%^&*)(_=+[}{\]\\/";:?><|

--- a/src/constants/validation.constants.ts
+++ b/src/constants/validation.constants.ts
@@ -147,14 +147,14 @@ export const patterns = {
      */
     letterSymbols: /^[A-Za-z]+([a-zA-Z.' -])*[a-zA-Z.' -]+$/,
     /**
-     * @regex /^(?!.*\s{2,})(?!\s)[\p{L}\s'.-]{1,50}(?<!\s)$/u
+     * @regex /^(?!.*\s{2,})(?!\s)[\p{L}\s'.-]{1,50}$/u
      * @description This pattern matches any string that contains 1 to 50 characters, starts and ends with valid characters (letters, whitespace, period, single quote, or hyphen).
      * @example ValidationConstants.patterns.name.test("John Doe")
      * @example ValidationConstants.patterns.name.test("John-Doe")
      * @example ValidationConstants.patterns.name.test("John O'Doe")
      * @example ValidationConstants.patterns.name.test("John O. Doe")
      */
-    name: /^(?!.*\s{2,})(?!\s)[\p{L}\s'.-]{1,50}(?<!\s)$/u,
+    name: /^(?!.*\s{2,})(?!\s)[\p{L}\s'.-]{1,50}$/u,
     /**
      * @regex /[`~!@#$%^&*)(_=+[}{\]\\/";:?><|]+/
      * @description This pattern matches any string that contains any of these characters: `~!@#$%^&*)(_=+[}{\]\\/";:?><|

--- a/utils-docs/docs/Constants/validation.md
+++ b/utils-docs/docs/Constants/validation.md
@@ -216,7 +216,7 @@ letterSymbols: /^[A-Za-z]+([a-zA-Z.' -])*[a-zA-Z.' -]+$/;
 
 ### name
 
-This pattern matches any string that contains **1-50** characters, starts and ends with valid characters (letters, whitespace, period, single quote, or hyphen) and can not be single space.
+This pattern matches any string that contains **1-50** characters, starts and ends with valid characters (letters, whitespace, period, single quote, or hyphen) and can not be single space or have two sequential spaces.
 
 ```JS
 // @example ValidationConstants.patterns.name.test("John Doe")

--- a/utils-docs/docs/Constants/validation.md
+++ b/utils-docs/docs/Constants/validation.md
@@ -216,14 +216,14 @@ letterSymbols: /^[A-Za-z]+([a-zA-Z.' -])*[a-zA-Z.' -]+$/;
 
 ### name
 
-This pattern matches any string that contains **2-50** characters, starts and ends with valid characters (letters, whitespace, period, single quote, or hyphen).
+This pattern matches any string that contains **1-50** characters, starts and ends with valid characters (letters, whitespace, period, single quote, or hyphen) and can not be single space.
 
 ```JS
 // @example ValidationConstants.patterns.name.test("John Doe")
 // @example ValidationConstants.patterns.name.test("John-Doe")
 // @example ValidationConstants.patterns.name.test("John O'Doe")
 // @example ValidationConstants.patterns.name.test("John O. Doe")
-name: /^(?!.*\s{2,})[\p{L}\s'.-]{2,50}$/u;
+name: /^(?!.*\s{2,})(?!\s)[\p{L}\s'.-]{1,50}$/u;
 ```
 
 ### general


### PR DESCRIPTION
As Backend updated the API to accept 1 character ( due to the Chinese language) we need to update the regex and also as whitespace is accepted and BE accepting 1 space also we should not accept space for the beginning and end of the characters. 


