### PR TITLE
chore: fix promise util types

### DIFF
--- a/src/utils/promise.utils.ts
+++ b/src/utils/promise.utils.ts
@@ -3,14 +3,32 @@
  * This allows for the promise to be resolved or rejected at a later time
  * outside of the promise constructor callback.
  *
- * @template T The type of the value with which the promise will be resolved.
- * @template U The type of the reason with which the promise will be rejected.
+ * @template T The type of the value with which the promise will be resolved. Defaults to `void` if not specified.
+ * @template U The type of the reason with which the promise will be rejected. Defaults to `unknown`.
  * @returns An object containing:
  * - `promise`: A Promise<T> that can be awaited or otherwise used.
- * - `resolve`: A function that, when called with a value of type T, resolves the promise.
- * - `reject`: A function that, when called with a reason of type U (defaults to unknown), rejects the promise.
+ * - `resolve`: A function that resolves the promise. If `T` is `void`, no arguments are required.
+ * - `reject`: A function that, when called with a reason of type U, rejects the promise.
  */
-export const createPromise = <T = unknown, U = unknown>() => {
+export function createPromise(): {
+    promise: Promise<void>;
+    resolve: () => void;
+    reject: (reason: unknown) => void;
+};
+
+export function createPromise<T>(): {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason: unknown) => void;
+};
+
+export function createPromise<T, U = unknown>(): {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason: U) => void;
+};
+
+export function createPromise<T = void, U = unknown>() {
     let deferredResolve!: (value: T) => void;
     let deferredReject!: (reason: U) => void;
 
@@ -24,4 +42,4 @@ export const createPromise = <T = unknown, U = unknown>() => {
         resolve: deferredResolve,
         reject: deferredReject,
     };
-};
+}

--- a/src/utils/promise.utils.ts
+++ b/src/utils/promise.utils.ts
@@ -10,7 +10,7 @@
  * - `resolve`: A function that, when called with a value of type T, resolves the promise.
  * - `reject`: A function that, when called with a reason of type U (defaults to unknown), rejects the promise.
  */
-export const createPromise = <T, U = unknown>() => {
+export const createPromise = <T = unknown, U = unknown>() => {
     let deferredResolve!: (value: T) => void;
     let deferredReject!: (reason: U) => void;
 

--- a/src/utils/promise.utils.ts
+++ b/src/utils/promise.utils.ts
@@ -4,16 +4,17 @@
  * outside of the promise constructor callback.
  *
  * @template T The type of the value with which the promise will be resolved.
+ * @template U The type of the reason with which the promise will be rejected.
  * @returns An object containing:
  * - `promise`: A Promise<T> that can be awaited or otherwise used.
  * - `resolve`: A function that, when called with a value of type T, resolves the promise.
- * - `reject`: A function that, when called with a reason, rejects the promise.
+ * - `reject`: A function that, when called with a reason of type U (defaults to unknown), rejects the promise.
  */
-export const createPromise = <T>() => {
-    let deferredResolve!: (value?: T | null) => void;
-    let deferredReject!: (reason?: unknown) => void;
+export const createPromise = <T, U = unknown>() => {
+    let deferredResolve!: (value: T) => void;
+    let deferredReject!: (reason: U) => void;
 
-    const promise = new Promise<T | undefined | null>((resolve, reject) => {
+    const promise = new Promise<T>((resolve, reject) => {
         deferredResolve = resolve;
         deferredReject = reject;
     });


### PR DESCRIPTION
**Description**

- Remove null and defined types. Consumers must pass this instead from their side.