### PR TITLE
likhith/fix: phone number validation regex

### DIFF
--- a/src/constants/validation.constants.ts
+++ b/src/constants/validation.constants.ts
@@ -104,11 +104,11 @@ export const patterns = {
      **/
     taxIdentificationNumber: /^(?!^$|\s+)[A-Za-z0-9.\/\s-]{0,25}$/,
     /**
-     * @regex /^\+((-|\s)*[0-9]){8,35}$/
-     * @description This pattern matches any string that starts with a '+' character, followed by 8-35 digits, allowing hyphens or spaces.
+     * @regex /^\+((-|\s)*[0-9]){9,35}$/
+     * @description This pattern matches any string that starts with a '+' character, followed by 9-35 digits, allowing hyphens or spaces.
      * @example ValidationConstants.patterns.phoneNumber.test("+1234567890")
      **/
-    phoneNumber: /^\+((-|\s)*[0-9]){8,35}$/,
+    phoneNumber: /^\+((-|\s)*[0-9]){9,35}$/,
     /**
      * @regex /(image|application)\/(jpe?g|pdf|png)$/
      * @description This pattern matches any of the file types jpeg, jpg, pdf, or png.


### PR DESCRIPTION
The Phone number regex used in APIs `new_account_wallet` & `new_account_real` need to be consistent and match the requirement Starting with + followed by 9-35 digits, allowing hyphens or space.