### PR TITLE
Potential fix for code scanning alert no. 2: Overly permissive regular expression range

### DIFF
--- a/src/constants/validation.constants.ts
+++ b/src/constants/validation.constants.ts
@@ -31,7 +31,7 @@ export const patterns = {
      * @example ValidationConstants.patterns.addressState.test("New York")
      * @example ValidationConstants.patterns.addressState.test("Québec")
      **/
-    addressState: /^[\p{L}\p{Nd}\s'.,(),-;]{0,100}$/u,
+    addressState: /^[\p{L}\p{Nd}\s'.,();-]{0,100}$/u,
     /**
      * @regex /^(?=.{1,20}$)[+-]?[0-9]+\.?[0-9]*$/
      * @description This pattern matches any string with 0-9 characters (numeric values. i.e. both integers and floats), and may contain a '+' or '-' sign.


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-utils/security/code-scanning/2](https://github.com/deriv-com/deriv-utils/security/code-scanning/2)

To fix the issue, we need to replace the overly permissive range `,-;` with an explicit list of the intended characters: `,`, `-`, and `;`. This ensures that the regex matches only the desired characters and avoids unintended matches. The corrected regex will explicitly list all allowed characters without relying on ambiguous ranges.

The specific change will be made to the `addressState` pattern on line 34. The updated regex will replace `,-;` with `,;-` to explicitly include only the intended characters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
