### PR TITLE
Potential fix for code scanning alert no. 4: Overly permissive regular expression range

### DIFF
--- a/src/constants/validation.constants.ts
+++ b/src/constants/validation.constants.ts
@@ -31,7 +31,7 @@ export const patterns = {
      * @example ValidationConstants.patterns.addressState.test("New York")
      * @example ValidationConstants.patterns.addressState.test("Québec")
      **/
-    addressState: /^[\p{L}\p{Nd}\s'.,-;\[\]\(\)]{0,100}$/u,
+    addressState: /^[\p{L}\p{Nd}\s'.,;\-\[\]\(\)]{0,100}$/u,
     /**
      * @regex /^(?=.{1,20}$)[+-]?[0-9]+\.?[0-9]*$/
      * @description This pattern matches any string with 0-9 characters (numeric values. i.e. both integers and floats), and may contain a '+' or '-' sign.


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-utils/security/code-scanning/4](https://github.com/deriv-com/deriv-utils/security/code-scanning/4)

To fix the issue, the overly permissive range `,-;` should be replaced with an explicit list of the intended characters: `,`, `-`, and `;`. This ensures that the regex matches only the desired characters and avoids unintended matches. The corrected regex will use a character class with these characters explicitly listed.

The change will be made in the `addressState` pattern on line 34 of the file `src/constants/validation.constants.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
