### PR TITLE
fix: override transitive handlebars dependency to 4.7.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6346,11 +6346,10 @@
             "license": "MIT"
         },
         "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.5",
                 "neo-async": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
         "prepublish": "npm run rebuild && npm run test",
         "commitlint": "commitlint --edit"
     },
+    "overrides": {
+        "handlebars": "^4.7.9"
+    },
     "dependencies": {
         "js-cookie": "^3.0.5"
     },


### PR DESCRIPTION
Pins handlebars to ^4.7.9 via npm overrides to resolve security vulnerability in the transitive dependency introduced via @semantic-release/release-notes-generator and semantic-release.